### PR TITLE
Add netstat to diagnose.sh

### DIFF
--- a/diagnose.sh
+++ b/diagnose.sh
@@ -48,6 +48,7 @@ commands=(
 	"cat /proc/net/udp"
 	"cat /proc/net/snmp"
 	"netstat -ntl"
+	"curl --max-time 5 localhost:48484/ping"
 	"$docker_name --version"
 	"ping -c 1 -W 3 google.co.uk"
 	"$docker_name images"


### PR DESCRIPTION
Today I bumped into a device where the supervisor container was appearing to run normally but had no logs. I often run `netstat -ntl` on the hostOS; if `48484` port is not marked as listening, it is an indication that the supervisor app in the container is not functioning properly