### PR TITLE
dependency: add natives module for Node 11 builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "mixpanel": "0.7.0",
     "mkdirp-promise": "5.0.1",
     "mocha": "3.5.0",
+    "natives": "^1.1.6",
     "resin-cli-visuals": "1.4.0",
     "resin-settings-client": "3.8.1",
     "resin-token": "4.2.1"


### PR DESCRIPTION
Required by gulp on node 11.
See more in https://github.com/gulpjs/gulp/issues/2246

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>