### PR TITLE
Update README with fresher ssh access instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 ### Prerequisites
 
-This script is pretty basic for now - ~~it assumes you have an ssh alias `resin`
-hooked up to the resin management servers and all appropriate ssh keys in
-place~~ - see the entry in the [scratch pad][scratch] for details on how to do
-this.
+This script is pretty basic for now.
 
 This script requires an existing account on the resin environment that the
 device is on. It also requires that the local ssh keys are stored in the resin
-account (**This does not mean the master ssh key, the master ssh key is not
-needed anymore at all**). Just use the same ssh keys you would to push to the
+account. Just use the same ssh keys you would to push to the
 resin account. The resin account needs access to the device to be leeched,
 either the device is owned by the account, or the accout is a support agent and
 the device is open for support or the account is an admin account.
+
+Make sure you invoked [`resin login`](https://github.com/balena-io/process/blob/master/process/support/accessing_user_accounts_and_devices.md#step-2-connect-to-the-users-device) prior to using this tool.
+
 
 ## Using
 


### PR DESCRIPTION
I was setting up `leech` on a new machine and noticed that the
scratchpad link does not work for me. I've documented the process I
needed to follow to set `leech` up, basically just doing `resin login`
was enough.
