### PR TITLE
circleci: bump image used to fix CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - checkout
       - restore_cache:
@@ -24,7 +24,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Debian Jessie struck here too.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>