### PR TITLE
diagnose: remove extra is_mounted function

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -179,12 +179,6 @@ function get_meminfo_field()
 	grep "^$1:" /proc/meminfo | awk '{print $2}'
 }
 
-function is_mounted()
-{
-	# busybox grep doesn't like long options.
-	mount | grep -q "on $1"
-}
-
 function check_under_voltage(){
 	if dmesg | grep -q "Under-voltage detected\!"; then
 		echo "WARNING: Under-voltage events detected, check/change the power supply ASAP"


### PR DESCRIPTION
This is_mounted function isn't used anywhere (it was a relic of resin1x that didn't get removed in df281b7)

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>