### PR TITLE
diagnostics: split check and data collection tasks

### DIFF
--- a/checks-description.md
+++ b/checks-description.md
@@ -1,0 +1,66 @@
+# Check Descriptions
+
+As part of the diagnostics suite, you will find various checks that can be run on-device. Below is a description of each
+check and what each means or how to triage.
+
+A `check` in this context is defined as a function that returns a result (good/bad status plus some descriptive text), whereas a
+command is simply a data collection tool without any filtering or logic built in). Checks are intended to be used by
+everyone, while typically command output is used by support/subject matter experts and power users.
+
+## `check_resin1x`
+### Summary
+As of SOME DATE, `resinOS 1.x` has been deprecated. These OSes are now unsupported.
+
+### Triage
+Upgrade your device to `balenaOS 2.x` (contact support).
+
+## `check_under_voltage`
+### Summary
+Often seen on Raspberry Pi devices, these kernel messages indicate that the power supply is insufficient for the device and any peripherals that might be attached. These errors also precede seemingly erratic behavior.
+
+### Triage
+Replace the power supply with a known-good supply (typically supplying at least 2.5V).
+
+## `check_memory`
+### Summary
+This check simply confirms that a given device is running at a given memory threshold (set to 90% at the moment).
+Oversubsribed memory can lead to OOM events.
+
+### Triage
+Using a tool like `top`, scan the process table for which process(es) are consuming the most memory (`%VSZ`) and check
+for memory leaks in those applications.
+
+## `check_container_engine`
+### Summary
+This check confirms the container engine is up and healthy. The container engine is an integral part of the balenaCloud
+pipeline.
+
+### Triage
+It is best to let balena's support team take a look before restarting the container engine. At the very least, take a
+diagnostics snapshot before restarting anything.
+
+## `check_supervisor`
+### Summary
+This check confirms the supervisor is up and healthy. The supervisor is an integral part of the balenaCloud pipeline.
+
+### Triage
+It is best to let balena's support team take a look before restarting the supervisor. At the very least, take a
+diagnostics snapshot before restarting anything.
+
+## `check_dns`
+### Summary
+Misconfigured DNS can often cause network issues if the local `dnsmasq` instance is bypassed. In the hostOS, the
+aforementioned instance should always be the first entry.
+
+### Triage
+Contact support to investigate further.
+
+## `check_diskspace`
+### Summary
+This check simply confirms that a given device is running beneath a given disk utilization threshold (set to 90% at the moment).
+If a local disk fills up, there are often knock-on issues in the supervisor and application containers.
+
+### Triage
+Run `du -a /mnt/data/docker | sort -nr | head -10` in the hostOS shell to list the ten largest files and directories.
+If the results indicate large files in `/mnt/data/docker/containers`, this result often indicates a leakage in an
+application container that can be cleaned up (runaway logs, too much local data, etc).

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+DIAGNOSE_VERSION=3.4.0
+# Don't run anything before this source as it sets PATH here
+# shellcheck disable=SC1091
+source /etc/profile
+# shellcheck disable=SC1091
+source /usr/sbin/resin-vars
+
+# Determine whether we're using the older 'rce'-aliased docker or not.
+# stolen directly from the proxy:
+# (https://github.com/balena-io/resin-proxy/blob/master/src/common/host-scripts.ts#L28)
+X=/usr/bin/
+ENG=rce
+[ -x $X$ENG ] || ENG=docker
+[ -x $X$ENG ] || ENG=balena
+[ -x $X$ENG ] || ENG=balena-engine
+
+# docker's mount is also the core btrfs filesystem.
+mountpoint="/var/lib/$ENG"
+
+low_mem_threshold=10 #%
+low_disk_threshold=10 #%
+
+slow_disk_write=1000 #ms
+GOOD="true"
+BAD="false"
+
+# Helper functions
+function announce_version()
+{
+	jq -n --arg dv "${DIAGNOSE_VERSION}" '{"diagnose_version":$dv}'
+}
+
+function get_meminfo_field()
+{
+	# Thankfully this works even with busybox :)
+	grep "^$1:" /proc/meminfo | awk '{print $2}'
+}
+
+function log_status()
+{
+	# success (g) ${1}
+	# function (f) ${2}
+	# status (s) ${3}
+	jq -cn --argjson g "${1}" --arg f "${2}" --arg s "${3}" '[{"name":$f,"success":$g,"status":$s}]'
+}
+
+# Check functions
+function check_under_voltage(){
+	if dmesg | grep -q "Under-voltage detected\!"; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "Under-voltage events detected, check/change the power supply ASAP"
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "No under-voltage events detected"
+	fi
+}
+
+function check_resin1x()
+{
+	# test resinOS 1.x based on matches like the following:
+	# VERSION="1.24.0"
+	# PRETTY_NAME="Resin OS 1.24.0"
+	if grep -q -e '^VERSION="1.*$' -e '^PRETTY_NAME="Resin OS 1.*$' /etc/os-release; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "resinOS 1.x is now completely deprecated"
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "balenaOS 2.x detected"
+	fi
+}
+
+function check_memory()
+{
+	total_kb=$(get_meminfo_field MemTotal)
+	avail_kb=$(get_meminfo_field MemAvailable)
+
+	if [ -z "$avail_kb" ]; then
+		# For kernels that don't support MemAvailable.
+		# Not as accurate, but a good approximation.
+
+		avail_kb=$(get_meminfo_field MemFree)
+		avail_kb=$((avail_kb + $(get_meminfo_field Cached)))
+		avail_kb=$((avail_kb + $(get_meminfo_field Buffers)))
+	fi
+
+	total_mb=$((total_kb/1024))
+	avail_mb=$((avail_kb/1024))
+
+	used_mb=$((total_mb - avail_mb))
+	percent=$((100*avail_kb/total_kb))
+
+	if [ "$percent" -lt "${low_mem_threshold}" ]; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "Low memory: ${percent}% (${avail_mb}%MB) available. ${used_mb}MB/${total_mb}MB used."
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "${percent}% memory available"
+	fi
+}
+
+function check_write_latency()
+{
+	# from https://www.kernel.org/doc/Documentation/iostats.txt:
+	#
+	# Field  5 -- # of writes completed
+	#     This is the total number of writes completed successfully.
+	# Field  8 -- # of milliseconds spent writing
+	#     This is the total number of milliseconds spent by all writes (as
+	#     measured from __make_request() to end_that_request_last()).
+	local write_output
+	write_output=$(awk -v limit=${slow_disk_write} '!/(loop|ram)/{if ($11/(($8>0)?$8:1)>limit){print $3": " $11/(($8>0)?$8:1) "ms / write, sample size" $8}}' /proc/diskstats)
+	if [ -n "${write_output}" ]; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "Slow disk writes detected: ${write_output}"
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "No slow disk writes detected"
+	fi
+}
+
+function check_diskspace()
+{
+
+	# Last +0 forces the field to a number, stripping the '%' on the end.
+	# Tested working on busybox.
+	used_percent=$(df ${mountpoint} | tail -n 1 | awk '{print $5+0}')
+	free_percent=$((100 - used_percent))
+
+	if [ "${free_percent}" -lt "${low_disk_threshold}" ]; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "Low disk space: (df reports ${free_percent}% free.)"
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "df reports ${free_percent}% free"
+	fi
+}
+
+function check_container_engine()
+{
+	if (! pidof $ENG >/dev/null); then
+		log_status "${BAD}" "${FUNCNAME[0]}" "Container engine ${ENG} is NOT running!"
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "Container engine ${ENG} is running!"
+	fi
+}
+
+function check_supervisor()
+{
+	container_running=$($ENG ps | grep resin_supervisor)
+	if [ -z "$container_running" ]; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "Supervisor is NOT running!"
+	else
+		log_status "${GOOD}" "${FUNCNAME[0]}" "Supervisor is running"
+	fi
+}
+
+function check_dns()
+{
+	if [ ! -f /etc/resolv.conf ]; then
+		log_status "${BAD}" "${FUNCNAME[0]}" "/etc/resolv.conf missing!"
+		return
+	fi
+
+	first_server=$(grep "^nameserver" /etc/resolv.conf | \
+				  head -n 1 | \
+				  awk '{print $2}')
+
+	log_status "${GOOD}" "${FUNCNAME[0]}" "First DNS server is ${first_server}"
+}
+
+function run_checks()
+{
+	# TODO remove echo | jq
+	echo "$(check_resin1x)" \
+	"$(check_under_voltage)" \
+	"$(check_memory)" \
+	"$(check_container_engine)" \
+	"$(check_supervisor)" \
+	"$(check_dns)" \
+	"$(check_diskspace)" \
+	"$(check_write_latency)" \
+	| jq -s 'add | {checks:.}'
+}
+
+jq --argjson a1 "$(announce_version)" --argjson a2 "$(run_checks)" -cn '$a1 + $a2'

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -57,16 +57,17 @@ module.exports = {
     // We need to update both the `package.json` and `diagnose.sh` file here
     const fs = require('fs');
     const packageFile = `${cwd}/package.json`;
-    const diagnoseScript = `${cwd}/scripts/diagnose.sh`;
     let packageData = require(packageFile);
     packageData.version = version;
     fs.writeFileSync(packageFile, `${JSON.stringify(packageData, null, 2)}\n`);
-
-    // Now update the version in diagnose.sh
-    const data = fs.readFileSync(diagnoseScript, 'utf8')
-    // Alter the DIAGNOSE_VERSION in the script
-    const result = data.replace(/DIAGNOSE_VERSION=[0-9\.]*/g, `DIAGNOSE_VERSION=${version}`);
-    fs.writeFileSync(diagnoseScript, result);
+    const filesToUpdate = [ `${cwd}/scripts/diagnose.sh`,`${cwd}/scripts/checks.sh`];
+    for (var i = 0; i < filesToUpdate.length; i++) {
+        // Now update the version
+        const data = fs.readFileSync(filesToUpdate[i], 'utf8')
+        // Alter the DIAGNOSE_VERSION in the script
+        const result = data.replace(/DIAGNOSE_VERSION=[0-9\.]*/g, `DIAGNOSE_VERSION=${version}`);
+        fs.writeFileSync(filesToUpdate[i], result);
+    }
   },
 
   template: [


### PR DESCRIPTION
A `check` in this context is defined as a function that returns a result
(good/bad status plus some descriptive text), whereas a command is
simply a data collection tool without any filtering or logic built in).
Checks are intended to be used by everyone, while typically 
output is used by support/subject matter experts and power users.

Connects-to: https://github.com/balena-io/device-diagnostics/issues/51
Change-type: major
Signed-off-by: Matthew McGinn <matthew@balena.io>