### PR TITLE
checks: make check_timesync backwards compatible

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -127,7 +127,7 @@ function check_write_latency()
 function check_timesync()
 {
 	local is_time_synced
-	is_time_synced=$(timedatectl show --value -p NTPSynchronized)
+	is_time_synced=$(timedatectl | awk -F": " '/(System clock|NTP) synchronized:/{print $2}')
 	if [[ "${is_time_synced}" != "yes" ]]; then
 		log_status "${BAD}" "${FUNCNAME[0]}" "Time is not being synchronized via NTP"
 	else


### PR DESCRIPTION
Connects-to: https://github.com/balena-io/device-diagnostics/issues/126
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>