### PR TITLE
meta: update codeowners to include gareth for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *	@wrboyce @xginn8 @zubairlk
+*.md	@garethdavies @wrboyce @xginn8 @zubairlk


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>