### PR TITLE
Add documentation for check_image_corruption to diagnostics.md

### DIFF
--- a/diagnostics.md
+++ b/diagnostics.md
@@ -166,6 +166,17 @@ This test depends on the container engine being healthy (see [check_container_en
 Depending on what part of this check failed, there are various fixes and workarounds. Most however will involve a
 restrictive local network, or an unreliable connection.
 
+
+### check_image_corruption
+#### Summary
+This check verifies container image layers stored on the device.  If it fails, at least one image has been corrupted.
+
+#### Triage
+Check that the device has sufficient disk space (see [check_localdisk](#check_localdisk)).  If this does not resolve the issue, it is best to contact support for further assistance.
+
+#### Depends on
+This check depends on the container engine being healthy (see [check_container_engine](#check_container_engine)) and having sufficient disk space (see [check_localdisk](#check_localdisk)).
+
 ### check_user_services
 #### Summary
 Any checks with names beginning with `service_` come from user applications. These checks allow users to provide their


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Hugh Brown <hugh@balena.io>

While going through the Advanced CLI masterclass, I had a device that failed the `check_image_corruption` diagnostic.  When displayed in the dashboard (staging, for the record), the link to further information (https://www.balena.io/docs/reference/diagnostics/#check_image_corruption) did not work.  This PR is meant to address that.

I've tried to create a good summary of the problem, but suggestions are most welcome.  In particular, I'm unsure about the link to `balena-engine image prune`: I'm not certain if we generally give customers commands to run on the device, and I don't know if we have a better/prettier page to link to for `balena-engine` commands (as we do for [balena-cli](https://www.balena.io/docs/reference/balena-cli/)).