### PR TITLE
remove gareth as codeowner of markdown

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 *	@saintaardvark @wrboyce @xginn8 @zubairlk
-*.md	@garethdavies @saintaardvark @wrboyce @xginn8 @zubairlk


### PR DESCRIPTION
i got the syntax wrong anyway

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>