### PR TITLE
check_balenaOS: adjust query to reflect public apps (ESR support)

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -293,12 +293,14 @@ function check_balenaOS()
 			log_status "${BAD}" "${FUNCNAME[0]}" "Custom balenaOS 2.x detected (custom device type)"
 			return
 		fi
-		local versions
-		versions=$(CURL_CA_BUNDLE=${TMPCRT} curl -qs --max-time 5 --retry 3 --retry-connrefused "${API_ENDPOINT}/device-types/v1/${SLUG}/images")
-		if ! echo "${versions}" | jq -e --arg v "${VERSION}.${VARIANT_ID}" '.versions | index($v)' > /dev/null; then
-			local latest
-			latest=$(echo "${versions}" | jq -r '.latest' | sed -e 's/\.prod$//;s/\.dev$//')
-			log_status "${BAD}" "${FUNCNAME[0]}" "balenaOS 2.x detected, but this version is not currently available in ${API_ENDPOINT} (latest version is ${latest})"
+		local -i versions
+		versions=$(CURL_CA_BUNDLE=${TMPCRT} curl -qs --retry 3 --max-time 5 --retry-connrefused -X GET \
+			-H "Content-Type: application/json" \
+			-H "Authorization: Bearer ${DEVICE_API_KEY}" \
+			"${API_ENDPOINT}/v5/release?\$expand=release_tag,belongs_to__application,contains__image/image&\$filter=(belongs_to__application/any(a:a/device_type%20eq%20'${SLUG}'))%20and%20(release_tag/any(rt:(rt/tag_key%20eq%20'version')%20and%20(rt/value%20eq%20'${VERSION}')))" \
+			| jq -r ".d[] | select(.release_tag[].value == (\"${VARIANT}\" | ascii_downcase)) | length")
+		if (( versions < 1 )); then
+			log_status "${BAD}" "${FUNCNAME[0]}" "balenaOS 2.x detected, but this version is not currently available in ${API_ENDPOINT}"
 		else
 			log_status "${GOOD}" "${FUNCNAME[0]}" "Supported balenaOS 2.x detected"
 		fi


### PR DESCRIPTION
This is the same logic used in resinhup to perform delta updates: https://github.com/balena-os/resinhup/blob/master/upgrade-2.x.sh#L721-L730

Connects-to: https://github.com/balena-io/device-diagnostics/issues/156
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>