### PR TITLE
Include count of under-voltage events when reporting problems

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -251,8 +251,10 @@ function check_localdisk()
 function check_under_voltage(){
 	local SLUG_WHITELIST=('raspberrypi3-64' 'raspberrypi4-64' 'raspberry-pi' 'raspberry-pi2' 'raspberrypi3' 'fincm3')
 	if is_valid_check WHITELIST "${SLUG_WHITELIST[*]}"; then
-		if dmesg | grep -q "Under-voltage detected\!"; then
-			log_status "${BAD}" "${FUNCNAME[0]}" "Under-voltage events detected, check/change the power supply ASAP"
+		local -i UNDERVOLTAGE_COUNT
+		UNDERVOLTAGE_COUNT=$(dmesg | grep -c "Under-voltage detected\!")
+		if (( UNDERVOLTAGE_COUNT > 0 )); then
+			log_status "${BAD}" "${FUNCNAME[0]}" "${UNDERVOLTAGE_COUNT} under-voltage events detected, check/change the power supply ASAP"
 		else
 			log_status "${GOOD}" "${FUNCNAME[0]}" "No under-voltage events detected"
 		fi


### PR DESCRIPTION
This adds a count of under-voltage events.  

Testing on my RPi4, happy case:

```
# ./checks.sh | jq '.checks[] | select (.name == "check_under_voltage")'
{
  "name": "check_under_voltage",
  "success": true,
  "status": "No under-voltage events detected"
}
```

Sad case:
```
# echo '<4>Under-voltage detected!' > /dev/kmsg 
# echo '<4>Under-voltage detected!' > /dev/kmsg 
# ./checks.sh | jq '.checks[] | select (.name == "check_under_voltage")'
{
  "name": "check_under_voltage",
  "success": false,
  "status": "2 under-voltage events detected, check/change the power supply ASAP"
}
```

Connects-to: #217
Change-type: minor
Signed-off-by: Hugh Brown <hugh@balena.io>