### PR TITLE
Remove image corruption check, as it is currently too noisy

### DIFF
--- a/diagnostics.md
+++ b/diagnostics.md
@@ -172,23 +172,6 @@ This test depends on the container engine being healthy (see [check_container_en
 Depending on what part of this check failed, there are various fixes and workarounds. Most however will involve a
 restrictive local network, or an unreliable connection.
 
-
-### check_image_corruption
-#### Summary
-This check verifies container image layers stored on the device.  If the check reports that images are corrupted, there
-is likely an issue with the engine corrupting layers that constitute an image. If the check reports that a timeout has
-occurred, more investigation is needed (see https://github.com/balena-io/device-diagnostics/issues/203 for more
-information). In order to return the checks in a timely fashion, the process is timed out rather than being allowed to
-complete in an arbitrary amount of time.
-
-#### Triage
-Check that the device has sufficient disk space (see [check_localdisk](#check_localdisk)).  If this does not resolve the
-issue, it is best to contact support for further assistance.
-
-#### Depends on
-This check depends on the container engine being healthy (see [check_container_engine](#check_container_engine)) and
-having sufficient disk space (see [check_localdisk](#check_localdisk)).
-
 ### check_user_services
 #### Summary
 Any checks with names beginning with `service_` come from user applications. These checks allow users to provide their


### PR DESCRIPTION
This check in its current form has a number of disadvantages:

- It causes a lot of IO.  Under the hood, balena-engine is:

  - reading the individual layers;
  - writing them out to /var/lib/docker/tmp;
  - then reading them all back in, so it can write to stdout.

- One consequence is that the `docker save` command can take longer than the current 10s timeout (particularly if there are a lot of images, or if the images are large), despite the device and its storage being perfectly healthy.

- While it is good to know if an image has corruption, it's probably more important to know if the underlying storage is having problems; this check is not a great way of determining if that is happening.

Thus, for now we're better off without this check.  We can investigate other approaches to verifying images, or examining storage for problems.

Testing on my device:

```
# ./checks.sh | jq .                                                                                                                                                                      
{
  "diagnose_version": "4.17.15",
  "checks": [
    {
      "name": "check_balenaOS",
      "success": true,
      "status": "Supported balenaOS 2.x detected"
    },
    {
      "name": "check_under_voltage",
      "success": false,
      "status": "Under-voltage events detected, check/change the power supply ASAP"
    },
    {
      "name": "check_memory",
      "success": true,
      "status": "91% memory available"
    },
    {
      "name": "check_temperature",
      "success": true,
      "status": "No abnormal temperature detected"
    },
    {
      "name": "check_container_engine",
      "success": true,
      "status": "Container engine balena is running and has not restarted uncleanly"
    },
    {
      "name": "check_supervisor",
      "success": true,
      "status": "Supervisor is running & healthy"
    },
    {
      "name": "check_networking",
      "success": true,
      "status": "No networking issues detected"
    },
    {
      "name": "check_localdisk",
      "success": true,
      "status": "No localdisk issues detected"
    },
    {
      "name": "check_service_restarts",
      "success": false,
      "status": "Some services are restarting unexpectedly: (service: /balena-cam_133169_110196 restart count: 130)"
    },
    {
      "name": "check_timesync",
      "success": true,
      "status": "Time is synchronized"
    },
    {
      "name": "check_os_rollback",
      "success": true,
      "status": "No OS rollbacks detected"
    }
  ]
}

```

Connects-to: #203
Change-type: minor
Signed-off-by: Hugh Brown <hugh@balena.io>