### PR TITLE
Detect CPU throttling events

### DIFF
--- a/diagnostics.md
+++ b/diagnostics.md
@@ -121,8 +121,21 @@ This check depends on a fully functional networking stack (see [check_networking
 
 ### check_temperature
 #### Summary
-If there are onboard temperature sensors, this check confirms that the temperature is below 80C (at which point
-throttling begins).
+This check looks for evidence of high temperature and CPU throttling.
+
+#### test_temperature_now
+##### Summary
+If there are sensors, this check confirms that the temperature is below 80C (at which point throttling begins).
+
+#### test_throttling_dmesg
+##### Summary
+
+This looks for evidence of CPU throttling in kernel log messages.
+
+#### test_throttling_vcgencmd
+##### Summary
+
+This test is currently limited to Raspberry Pi 4 devices, and uses the Raspberry Pi utility `vcgencmd get_throttled` to query the device for evidence of CPU throttling. 
 
 #### Triage
 In order to triage, either reduce the load on the device or replace/reseat/upgrade any heatsinks that may be attached to


### PR DESCRIPTION
This adds two checks that take different approaches to detecting CPU throttling:

- check_throttling_dmesg examines dmesg output for throttling events.  The original request at #183 was compared with [this page](https://access.redhat.com/solutions/134973);  

- check_throttling_vcgencmd examines the output of the Raspberry Pi utility `vcgencmd` to determine if throttling is currently happening, or has occurred in the past.

Testing, happy case:

```
# ./checks.sh | jq .
[snip]
    {
      "name": "check_throttling_dmesg",
      "success": true,
      "status": "No cpu throttling events detected"
    },
    {
      "name": "check_throttling_vcgencmd",
      "success": true,
      "status": "No Raspberry Pi throttling events detected"
    },
```

Sad case, dmesg:

```
# echo '<4>Temperature above threshold, cpu clock throttled' > /dev/kmsg 
# echo '<4>Temperature above threshold, cpu clock throttled' > /dev/kmsg 
# ./checks.sh | jq 
[snip]
    {
      "name": "check_throttling_dmesg",
      "success": false,
      "status": "2 cpu throttling events detected, check CPU temperature"
    },
```

Sad case, throttling:
```
# yes | /dev/null &
# ./checks.sh | jq 
[snip]
    {
      "name": "check_throttling_vcgencmd",
      "success": false,
      "status": "Raspberry Pi throttling events detected:  ARM freq capping has occurred"
    },
```

([Fun thread](https://stackoverflow.com/questions/2925606/how-to-create-a-cpu-spike-with-a-bash-command) on how to create a CPU spike with shell commands alone.)

Connects-to: #183, #209
Change-type: minor
Signed-off-by: Hugh Brown <hugh@balena.io>