### PR TITLE
timesync: check if DHCP passed in any local timeservers

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -147,6 +147,7 @@ commands=(
 
 	# TIME specific commands
 	'echo === TIME ==='
+	'cat /tmp/chrony_added_dhcp_ntp_servers'
 	'chronyc sources'
 	'chronyc tracking'
 	'date'


### PR DESCRIPTION
written to during config: https://github.com/balena-os/meta-balena/blob/9ace976ea9d757d3d928ed59ce60c4118bb9d557/meta-balena-common/recipes-connectivity/networkmanager/resin-files/99dhcp_ntp#L3

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>