### PR TITLE
Fix timeout 'command not found' error in diagnose.sh

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -24,7 +24,7 @@ GLOBAL_TIMEOUT=10
 GLOBAL_TIMEOUT_CMD="timeout --preserve-status --kill-after=$(( GLOBAL_TIMEOUT * 2 ))"
 TIMEOUT_VERBOSE="timeout -v 1"
 # timeout (GNU coreutils) 8.26 does not support -v
-if "${TIMEOUT_VERBOSE}" echo > /dev/null ; then
+if ${TIMEOUT_VERBOSE} echo > /dev/null 2>&1 ; then
 	GLOBAL_TIMEOUT_CMD="${GLOBAL_TIMEOUT_CMD} -v"
 fi
 GLOBAL_TIMEOUT_CMD="${GLOBAL_TIMEOUT_CMD} ${GLOBAL_TIMEOUT}"


### PR DESCRIPTION
The dashboard 'Standard error' display for 'Device Diagnostics' reports the following error:
'bash: line 27: timeout -v 1: command not found'

This issue is due to the double quotes used in the corresponding 'if' statement. Adding an additional redirect of stderr to this commands hides any error messages for the cases where the '-v' option is not supported by the version of 'timeout' being used.

This fix has been tested as a simple, isolated code snippet on the balenaOS (2.51.1+rev1) command line running on a RPi3.

Change-type: patch
Connects-to: #234
Signed-off-by: Mark Corbin <mark@balena.io>
