### PR TITLE
Check if the data partition is mounted read-write

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -209,9 +209,12 @@ function test_disk_expansion()
 
 function test_data_partition_mounted()
 {
-	if ! lsblk -J -o NAME,MOUNTPOINT | jq -er '.blockdevices[].children[]? | select (.mountpoint == "/mnt/data") | length >= 1' > /dev/null ; then
-		echo "${FUNCNAME[0]}" "Data partition not mounted"
-	fi
+	data_mounted=$(awk '($2 == "/mnt/data") {print $4}' /proc/mounts)
+	case $data_mounted in
+		*rw*) return ;;
+		*ro*) echo "${FUNCNAME[0]}" "Data partition not mounted read-write" ;;
+		"") echo "${FUNCNAME[0]}" "Data partition not mounted" ;;
+	esac
 }
 
 function is_valid_check()


### PR DESCRIPTION
This adds a check to verify that the `data` partition is mounted read-write.  `lsblk` doesn't examine the mounts of the filesystem to see if they're read-only, so I'm using the contents of `/proc/mount`; this seems like the easiest, most likely-to-stay-consistent way of determining all three cases (mounted rw, mounted ro, not mounted at all).  

Happy case:

```
rroot@1364988:/lib/systemd/system# mount | grep /mnt/data ; /tmp/checks.sh | jq '.checks[] | select (.name == "check_localdisk")'
/dev/mmcblk0p6 on /mnt/data type ext4 (rw,relatime)
{
  "name": "check_localdisk",
  "success": true,
  "status": "No localdisk issues detected"
}
```

Sad case -- mounted read-only:
```
root@1364988:/lib/systemd/system# mount | grep /mnt/data ; /tmp/checks.sh | jq '.checks[] | select (.name == "check_localdisk")'
/dev/mmcblk0p6 on /mnt/data type ext4 (ro,relatime)
Cannot connect to the balenaEngine daemon at unix:///var/run/balena-engine.sock. Is the balenaEngine daemon running?
{
  "name": "check_localdisk",
  "success": false,
  "status": "Some localdisk issues detected: \ntest_data_partition_mounted Data partition not mounted read-write"
}
```

Sad case -- not mounted at all:

```
root@1364988:/lib/systemd/system# umount /mnt/data
root@1364988:/lib/systemd/system# mount | grep /mnt/data ; /tmp/checks.sh | jq '.checks[] | select (.name == "check_localdisk")'
{
  "name": "check_localdisk",
  "success": false,
  "status": "Some localdisk issues detected: \ntest_data_partition_mounted Data partition not mounted"
}
```

Connects-to: #251 
Change-type: patch
Signed-off-by: Hugh Brown <hugh@balena.io>