### PR TITLE
Add md5sum fingerprint checking to diagnostics

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -135,6 +135,7 @@ commands=(
 	'sysctl -a'
 	'systemctl list-units --failed --no-pager'
 	'top -b -n 1'
+	'grep -vE \"/var/cache/ldconfig/aux-cache|md5sum|/etc/hostname|/etc/machine-id|/etc/resin-supervisor/supervisor.conf|/etc/systemd/timesyncd.conf|/home/root/.rnd\" /resinos.fingerprint | md5sum --quiet -c ' # https://github.com/balena-os/meta-balena/issues/1618
 
 	# SUPERVISOR specific commands
 	'echo === SUPERVISOR ==='


### PR DESCRIPTION
This adds md5sum fingerprint checking to `diagnose.sh`.  To accommodate https://github.com/balena-os/meta-balena/issues/1618, we explicitly skip checking `/var/cache/ldconfig/aux-cache` in order to avoid crashing vulnerable systems.

Checked on my devenv.  Happy case:

```
--- grep -v /var/cache/ldconfig/aux-cache /resinos.fingerprint | md5sum --quiet -c - ---

2020-10-23 18:44:44.358042552+00:00
real	0m 7.82s
user	0m 1.93s
sys	0m 1.12s
```

Sad case (two files modified, one removed):

```
--- grep -v /var/cache/ldconfig/aux-cache /resinos.fingerprint | md5sum --quiet -c - ---

2020-10-23 18:47:11.946180068+00:00
/etc/sysctl.conf: FAILED
/usr/share/ModemManager/mm-dell-dw5821e-carrier-mapping.conf: FAILED
/usr/share/usb_modeswitch/new.lst: FAILED open or read
Command exited with non-zero status 1
real	0m 1.45s
user	0m 1.21s
sys	0m 0.23s
```

The `stderr` for that case:

```
--- grep -v /var/cache/ldconfig/aux-cache /resinos.fingerprint | md5sum --quiet -c - ---

md5sum: /usr/share/usb_modeswitch/new.lst: No such file or directory
md5sum: WARNING: 1 listed file could not be read
md5sum: WARNING: 2 computed checksums did NOT match
```

Change-type: patch
Connects-to: #106
Signed-off-by: Hugh Brown <hugh@balena.io>